### PR TITLE
gh pages only supports rouge highlighter.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ permalink: /:categories/:title/
 kramdown:
   toc_levels: 1..2
   input: GFM
-highlighter: pygments
+highlighter: rouge
 plugins:
   - jekyll-sitemap
 collections:


### PR DESCRIPTION
Last merge caused a warning message, this should fix it.